### PR TITLE
Changed some axios defaults

### DIFF
--- a/face-analyzer/src/layout/MainLayout/index.js
+++ b/face-analyzer/src/layout/MainLayout/index.js
@@ -51,6 +51,13 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(({
   }
 }));
 
+// Axios
+// TODO: Really shouldn't use hardcoded (admin) tokens :)
+import axios from 'axios';
+axios.defaults.headers.common['Authorization'] = 'bearer ' + process.env.REACT_APP_ADMIN_TOKEN;
+axios.defaults.headers.common['Accept'] = 'text/plain';
+axios.defaults.headers.common['Content-Type'] = 'application/json';
+
 // ==============================|| MAIN LAYOUT ||============================== //
 
 const MainLayout = () => {


### PR DESCRIPTION
Added some axios defaults to make our dev lifes easier.

Modified the MainLayouts.js by directly changing the axios default headers to include the values needed by our API calls, effectively simplifying the whole process. A baseUrl can also be set, but I was unsure about using that. The only questionable thing is using the hardcoded tokens, but I believe that can easily be modified down the line (after we set up proper auth).