### PR TITLE
Added an error page

### DIFF
--- a/face-analyzer/package.json
+++ b/face-analyzer/package.json
@@ -28,6 +28,7 @@
     "react-apexcharts": "^1.4.0",
     "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-perfect-scrollbar": "^1.5.8",
     "react-redux": "^8.0.2",
     "react-router": "6.3.0",

--- a/face-analyzer/src/index.js
+++ b/face-analyzer/src/index.js
@@ -8,21 +8,25 @@ import { Provider } from 'react-redux';
 import * as serviceWorker from 'serviceWorker';
 import App from 'App';
 import { store } from 'store';
+import {ErrorBoundary} from "react-error-boundary";
 
 // style + assets
 import 'assets/scss/style.scss';
 import config from './config';
+import ErrorPage from "./views/error-page/ErrorPage";
 
 // ==============================|| REACT DOM RENDER  ||============================== //
 
 const container = document.getElementById('root');
 const root = createRoot(container); // createRoot(container!) if you use TypeScript
 root.render(
-  <Provider store={store}>
-    <BrowserRouter basename={config.basename}>
-      <App />
-    </BrowserRouter>
-  </Provider>
+    <Provider store={store}>
+        <BrowserRouter basename={config.basename}>
+            <ErrorBoundary fallbackRender={ErrorPage} onReset={() => location.href = '/'}>
+                <App />
+            </ErrorBoundary>
+        </BrowserRouter>
+    </Provider>
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/face-analyzer/src/views/error-page/ErrorPage.js
+++ b/face-analyzer/src/views/error-page/ErrorPage.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button, Typography } from '@mui/material';
+
+const ErrorPage = ({error, resetErrorBoundary}) => {
+    console.error("An error caused the Error page to show:", error);
+    return (
+        <div style={{ textAlign: 'center', padding: '20px' }}>
+            <Typography variant="h4" color="error" gutterBottom>
+                Oops! Something went wrong.
+            </Typography>
+            <Typography variant="body1" color="textSecondary" paragraph>
+                We apologize for the inconvenience. Please try again later.
+            </Typography>
+            <Button variant="contained" color="primary" onClick={resetErrorBoundary}>
+                Go Back to Homepage
+            </Button>
+        </div>
+    );
+};
+
+export default ErrorPage;


### PR DESCRIPTION
Added an error page that shows when an uncaught error occurs (e.g. trying to access a nonexistent experiment or stimuli). Before this the app would only show a blank page.